### PR TITLE
Fix response handling

### DIFF
--- a/lib/exact_target_rest/interaction_event.rb
+++ b/lib/exact_target_rest/interaction_event.rb
@@ -19,7 +19,7 @@ module ExactTargetRest
           p.body = @params_formatter.transform(params)
         end
         raise NotAuthorizedError if resp.status == 401
-        raise StandardError.new(resp.body) if resp.status != 200 and resp.status != 401
+        raise StandardError.new(resp.body) unless resp.success?
         resp
       end
     end

--- a/spec/lib/exact_target_rest/intercation_event_spec.rb
+++ b/spec/lib/exact_target_rest/intercation_event_spec.rb
@@ -37,8 +37,8 @@ describe InteractionEvent do
         .to raise_error(NotAuthorizedError)
     end
 
-    describe "raises StandardError if status code is not 200 or 401:" do
-      [400, 404, 500].each do |status_code|
+    describe "raises StandardError if status code is not successful (200..299):" do
+      [400, 404, 500, 503, 504].each do |status_code|
         it "status code #{status_code}" do
           stub_request(:post, start_journey_path)
             .with(self.request_data)
@@ -48,6 +48,19 @@ describe InteractionEvent do
             subject.start_journey(event_definition_key: 'event_definition_key', contact_key: 'contact_key')
           }
             .to raise_error(StandardError, 'Error message')
+        end
+      end
+    end
+
+    describe "No error raised if status code is successful (200..299):" do
+      (200..204).each do |status_code|
+        it "status code #{status_code}" do
+          stub_request(:post, start_journey_path)
+            .with(self.request_data)
+            .to_return(self.response_data)
+
+          expect(subject.start_journey(event_definition_key: 'event_definition_key', contact_key: 'contact_key').body)
+            .to eq({ 'eventInstanceId' => event_instance_id })
         end
       end
     end


### PR DESCRIPTION
Fix response handling when initiating user journey. API returns 201 status code, and code explicitly expected 200. Change is to accept any status code for success (in this case Faraday interprets 200..299 range to be all success status codes)