### PR TITLE
Bump version of ruby and bundler

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -1,7 +1,7 @@
 name: exact-target-rest
 
 up:
-  - ruby: 2.6.5
+  - ruby: 3.1.0
   - bundler
 
 commands:

--- a/exact_target_rest.gemspec
+++ b/exact_target_rest.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'faraday', '~> 1.8'
   spec.add_dependency 'faraday_middleware', '~> 1.2'
 
-  spec.add_development_dependency 'bundler', '~> 2.1.4'
+  spec.add_development_dependency 'bundler', '~> 2.3.4'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'guard-rspec', '~> 4.5'
   spec.add_development_dependency 'pry', '~> 0.13'

--- a/lib/exact_target_rest/data_extension.rb
+++ b/lib/exact_target_rest/data_extension.rb
@@ -25,7 +25,7 @@ module ExactTargetRest
     def upsert(data_extension_rows)
       @authorization.with_authorization do |access_token|
         resp = endpoint.post do |p|
-          p.url(format(DATA_EXTENSION_PATH, URI.encode(@external_key)))
+          p.url(format(DATA_EXTENSION_PATH, Addressable::URI.encode(@external_key)))
           p.headers['Authorization'] = "Bearer #{access_token}"
           p.body = @param_formatter.transform(data_extension_rows)
         end

--- a/lib/exact_target_rest/triggered_send.rb
+++ b/lib/exact_target_rest/triggered_send.rb
@@ -64,7 +64,7 @@ module ExactTargetRest
 
       @authorization.with_authorization do |access_token|
         resp = endpoint.post do |p|
-          p.url(format(TRIGGERED_SEND_PATH, URI.encode(@external_key)))
+          p.url(format(TRIGGERED_SEND_PATH, Addressable::URI.encode(@external_key)))
           p.headers['Authorization'] = "Bearer #{access_token}"
           p.body = {
             From: {

--- a/spec/lib/exact_target_rest/authorization_spec.rb
+++ b/spec/lib/exact_target_rest/authorization_spec.rb
@@ -66,7 +66,7 @@ describe Authorization do
     it "serializes and deserializes Authorization" do
       auth = subject.new(auth_url, client_id, client_secret).authorize!
 
-      expect(YAML::load(auth.to_yaml)).to be_instance_of(ExactTargetRest::Authorization)
+      expect(YAML::unsafe_load(auth.to_yaml)).to be_instance_of(ExactTargetRest::Authorization)
     end
   end
 

--- a/spec/lib/exact_target_rest/triggered_send_spec.rb
+++ b/spec/lib/exact_target_rest/triggered_send_spec.rb
@@ -68,7 +68,7 @@ describe TriggeredSend do
           subscriber_attributes: { "City" => "São Paulo", "Profile ID" => "42" }
         )
 
-      expect(YAML::load(ts.to_yaml)).to be_instance_of(ExactTargetRest::TriggeredSend)
+        expect(YAML::unsafe_load(ts.to_yaml)).to be_instance_of(ExactTargetRest::TriggeredSend)
     end
   end
 

--- a/spec/lib/exact_target_rest/triggered_send_spec.rb
+++ b/spec/lib/exact_target_rest/triggered_send_spec.rb
@@ -68,7 +68,7 @@ describe TriggeredSend do
           subscriber_attributes: { "City" => "São Paulo", "Profile ID" => "42" }
         )
 
-        expect(YAML::unsafe_load(ts.to_yaml)).to be_instance_of(ExactTargetRest::TriggeredSend)
+      expect(YAML::unsafe_load(ts.to_yaml)).to be_instance_of(ExactTargetRest::TriggeredSend)
     end
   end
 


### PR DESCRIPTION
I am trying to include this gem in core so after bumping the ruby version I was getting the following error in my test script:
```
NoMethodError: undefined method `encode' for URI:Module

          p.url(format(DATA_EXTENSION_PATH, URI.encode(@external_key)))
                                               ^^^^^^^
```
From this link https://stackoverflow.com/questions/68635238/undefined-method-encode-for-urimodule-with-gem-rspotify there was a suggestion on changing the `URI.encode` to `Addressable::Uri.encode`.  When I tested it outin the tests and in core with my branch as the target for the gem I was able to successfully upsert a table to ExactTarget.

I was also getting Psych::DisallowedClass error after bumping the ruby version in the tests and that appears to be a newer version on YAML load that has class restrictions on what it will load and they added an unsafe_load method that will suffice for the test cases:  http://sundivenetworks.com/archive/2021/tried-to-load-unspecified-class-time-psych-disallowedclass.html