### PR TITLE
Add addressable gem dep

### DIFF
--- a/exact_target_rest.gemspec
+++ b/exact_target_rest.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
+  spec.add_dependency 'addressable', '~> 2.8'
   spec.add_dependency 'faraday', '~> 1.8'
   spec.add_dependency 'faraday_middleware', '~> 1.2'
 


### PR DESCRIPTION
With my last PR I added a dependancy on Addressable but never included the gem in the Gemfile.

This PR adds in the dependancy.

Note addressable was coming in with webmock so this is now explicit. 